### PR TITLE
fix issue with composer install core dumping

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,16 +1,5 @@
 FROM php:7-alpine
 
-RUN set -ex \
- && echo "http://mirror1.hs-esslingen.de/pub/Mirrors/alpine/latest-stable/main" > /etc/apk/repositories \
- && apk update \
- && apk upgrade --available \
- && apk add bash \
-# Clean up anything else
- && rm -rf \
-    /tmp/* \
-    /var/tmp/* \
-    /var/cache/apk/*
-
 #
 # composer
 #

--- a/build/build
+++ b/build/build
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -ex
 
 cd /srv/www

--- a/build/install-composer.sh
+++ b/build/install-composer.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 EXPECTED_SIGNATURE=$(php -r "echo file_get_contents('https://composer.github.io/installer.sig');")
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"

--- a/data/config.php.dist
+++ b/data/config.php.dist
@@ -1,6 +1,10 @@
 <?php
 $jira_user = 'FIXME';
+
+// for Jira Cloud instances use an API key as password
 $jira_password = 'FIXME';
+
+// for Jira Cloud instances remove the "/jira" suffix
 $jira_url = 'https://jira.example.com/jira/';
 $export_dir = __DIR__ . '/../www/';
 


### PR DESCRIPTION
I tried to install using Docker, but the composer install breaks, probably due to an issue with curl.

The fix is not to update against the repo, which means that you can't add bash. So I changed the "build" and "composer-install" script to "sh" instead of "bash".

I have also added tow comments to the config.php file to help people with Jira Cloud configure correctly